### PR TITLE
Add: travis-ci build testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+{
+  "language": "bash",
+  "services": [
+    "docker"
+  ],
+  "before_install": [
+    "docker info",
+    "docker version",
+    "echo \"==> Build with Docker ...\"",
+    "docker run --rm -v \"$PWD:/gitbook\" -p 4000:4000 billryan/gitbook gitbook build"
+  ],
+  "dist": "trusty",
+  "os": "linux"
+}


### PR DESCRIPTION
Implements a really basic automated gitbook build test using travis-ci.
This should make pull request containing issues that could prevent the gitbook site from rebuilding successfully more obvious.

